### PR TITLE
error_reporting() 错误级别 抛出异常

### DIFF
--- a/start.php
+++ b/start.php
@@ -58,6 +58,11 @@ foreach ($property_map as $property) {
 }
 
 $worker->onWorkerStart = function ($worker) {
+    set_error_handler(function ($level, $message, $file = '', $line = 0, $context = []) {
+        if (error_reporting() & $level) {
+            throw new ErrorException($message, 0, $level, $file, $line);
+        }
+    });
     register_shutdown_function(function ($start_time) {
         if (time() - $start_time <= 1) {
             sleep(1);


### PR DESCRIPTION
出现类似以下的代码时会抛出` \ErrorException` 异常
```
<?php
try {
    $a = [];
    var_dump($a[1]);
} catch (\Throwable $throwable) {
    var_dump(get_class($throwable), $throwable->getMessage());
}
```