### PR TITLE
bugfixed:master与worker进程env方法行为不一致的问题并使系统环境变量优先级高于.env文件

### DIFF
--- a/start.php
+++ b/start.php
@@ -16,7 +16,7 @@ use support\bootstrap\Container;
 if (method_exists('Dotenv\Dotenv', 'createUnsafeImmutable')) {
     Dotenv::createUnsafeImmutable(base_path())->load();
 } else {
-    Dotenv::createMutable(base_path())->load();
+    Dotenv::createImmutable(base_path())->load();
 }
 
 Config::load(config_path(), ['route', 'container']);
@@ -71,10 +71,10 @@ $worker->onWorkerStart = function ($worker) {
     foreach (config('autoload.files', []) as $file) {
         include_once $file;
     }
-    if (method_exists('Dotenv\Dotenv', 'createUnsafeMutable')) {
-        Dotenv::createUnsafeMutable(base_path())->load();
+    if (method_exists('Dotenv\Dotenv', 'createUnsafeImmutable')) {
+        Dotenv::createUnsafeImmutable(base_path())->load();
     } else {
-        Dotenv::createMutable(base_path())->load();
+        Dotenv::createImmutable(base_path())->load();
     }
     Config::reload(config_path(), ['route', 'container']);
     foreach (config('bootstrap', []) as $class_name) {
@@ -113,7 +113,11 @@ foreach (config('process', []) as $process_name => $config) {
         foreach (config('autoload.files', []) as $file) {
             include_once $file;
         }
-        Dotenv::createMutable(base_path())->load();
+        if (method_exists('Dotenv\Dotenv', 'createUnsafeImmutable')) {
+            Dotenv::createUnsafeImmutable(base_path())->load();
+        } else {
+            Dotenv::createImmutable(base_path())->load();
+        }
         Config::reload(config_path(), ['route']);
 
         $bootstrap = $config['bootstrap'] ?? config('bootstrap', []);


### PR DESCRIPTION
在master和worker使用env方法获取的值不同，worker中env的变量会覆盖系统环境变量