### PR TITLE
Update log.php

### DIFF
--- a/config/log.php
+++ b/config/log.php
@@ -19,6 +19,7 @@ return [
                 'class' => Monolog\Handler\RotatingFileHandler::class,
                 'constructor' => [
                     runtime_path() . '/logs/webman.log',
+                    7, //$maxFiles
                     Monolog\Logger::DEBUG,
                 ],
                 'formatter' => [


### PR DESCRIPTION
monolog/monolog/src/Monolog/Handler/RotatingFileHandler.php RotatingFileHandler::class的构造函数
public function __construct(string $filename, int $maxFiles = 0, $level = Logger::DEBUG, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false)
如果不指定$maxFiles,那么实际上是用 Monolog\Logger::DEBUG = 100 来作为$maxFiles，同时日志级别采用默认的Logger::DEBUG