### PR TITLE
增加CLI命令行的支持：

### DIFF
--- a/app/command/config/MySQLCommand.php
+++ b/app/command/config/MySQLCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace app\command\config;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MySQLCommand extends \Symfony\Component\Console\Command\Command
+{
+    protected static $defaultName = 'config:mysql';
+    protected static $defaultDescription = '显示当前MySQL服务器配置';
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('MySQL配置信息如下：');
+        $config = config('database');
+        $headers = ['name', 'default', 'driver', 'host', 'port', 'database', 'username', 'password', 'unix_socket', 'charset', 'collation', 'prefix', 'strict', 'engine', 'schema', 'sslmode'];
+        $rows = [];
+        foreach ($config['connections'] as $name => $db_config) {
+            $row = [];
+            foreach ($headers as $key) {
+                switch ($key) {
+                    case 'name':
+                        $row[] = $name;
+                        break;
+                    case 'default':
+                        $row[] = $config['default'] == $name ? 'true' : 'false';
+                        break;
+                    default:
+                        $row[] = $db_config[$key] ?? '';
+                }
+            }
+            if ($config['default'] == $name) {
+                array_unshift($rows, $row);
+            } else {
+                $rows[] = $row;
+            }
+        }
+        $table = new Table($output);
+        $table->setHeaders($headers);
+        $table->setRows($rows);
+        $table->render();
+        return self::SUCCESS;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,9 @@
     "php": ">=7.2",
     "workerman/webman-framework": "^1.0",
     "monolog/monolog": "^2.0",
-    "vlucas/phpdotenv": ">=4.1,<6.0"
+    "vlucas/phpdotenv": ">=4.1,<6.0",
+    "symfony/console": "^5.3",
+    "symfony/finder": "^5.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5"
@@ -38,7 +40,7 @@
   "autoload": {
     "psr-4": {
       "app\\": "app/",
-      "support\\": "support"
+      "support\\": "support/"
     },
     "files": [
       "./support/helpers.php"

--- a/webman
+++ b/webman
@@ -1,0 +1,37 @@
+#!/usr/bin/env php
+<?php
+
+use Dotenv\Dotenv;
+use Symfony\Component\Console\Application as Cli;
+use Symfony\Component\Finder\Finder;
+use Webman\Bootstrap;
+use Webman\Config;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+if (method_exists('Dotenv\Dotenv', 'createUnsafeImmutable')) {
+    Dotenv::createUnsafeImmutable(base_path())->load();
+} else {
+    Dotenv::createMutable(base_path())->load();
+}
+Config::load(config_path(), ['route', 'container']);
+if ($timezone = config('app.default_timezone')) {
+    date_default_timezone_set($timezone);
+}
+foreach (config('autoload.files', []) as $file) {
+    include_once $file;
+}
+foreach (config('bootstrap', []) as $class_name) {
+    /** @var Bootstrap $class_name */
+    $class_name::start(null);
+}
+$cli = new Cli();
+$cli->setName('webman命令行工具');
+$finder = new Finder();
+$finder->name('*.php');
+foreach ($finder->in(app_path() . DIRECTORY_SEPARATOR . 'command')->files() as $file) {
+    $class_name = 'app\\command\\' . $file->getRelativePath() . '\\' . $file->getBasename('.php');
+    $cli->add(new $class_name);
+}
+
+$cli->run();


### PR DESCRIPTION
1.使用`symfony/console`实现
2.使用`symfony/finder`进行文件系统扫描
3.在`app`目录下新增`command`目录
使用方法：
在`app\command`目录下创建Command类即可,运行时会对`app\command`目录的所有类进行注册。本次提交提供了一个用于显示database配置的Command