### PR TITLE
增加 LaravelDb的静态方法提示

### DIFF
--- a/process/FileMonitor.php
+++ b/process/FileMonitor.php
@@ -44,7 +44,7 @@ class FileMonitor
             return;
         }
         $disable_functions = explode(',', ini_get('disable_functions'));
-        if (in_array('exec', $disable_functions)) {
+        if (in_array('exec', $disable_functions, true)) {
             echo "\nFileMonitor turned off because exec() has been disabled by disable_functions setting in " . PHP_CONFIG_FILE_PATH ."/php.ini\n";
             return;
         }
@@ -60,7 +60,7 @@ class FileMonitor
     /**
      * @param $monitor_dir
      */
-    public function check_files_change($monitor_dir)
+    public function check_files_change($monitor_dir): void
     {
         static $last_mtime;
         if (!$last_mtime) {
@@ -83,7 +83,7 @@ class FileMonitor
                 continue;
             }
             // check mtime
-            if ($last_mtime < $file->getMTime() && in_array($file->getExtension(), $this->_extensions)) {
+            if ($last_mtime < $file->getMTime() && in_array($file->getExtension(), $this->_extensions,true)) {
                 $var = 0;
                 exec(PHP_BINARY . " -l " . $file, $out, $var);
                 if ($var) {

--- a/support/Db.php
+++ b/support/Db.php
@@ -18,6 +18,15 @@ use Illuminate\Database\Capsule\Manager;
 /**
  * Class Db
  * @package support
+ * @method static array select(string $query, $bindings = [], $useReadPdo = true)
+ * @method static int insert(string $query, $bindings = [])
+ * @method static int update(string $query, $bindings = [])
+ * @method static int delete(string $query, $bindings = [])
+ * @method static bool statement(string $query, $bindings = [])
+ * @method static mixed transaction(\Closure $callback, $attempts = 1)
+ * @method static void beginTransaction()
+ * @method static void rollBack($toLevel = null)
+ * @method static void commit()
  */
 class Db extends Manager
 {


### PR DESCRIPTION
提升code体验，使用larabelDb的使用 原生方法没有方法提示，增加了静态方法提示。
添加了-FileMonitor.php: in_array() 第三个参数=true
