### PR TITLE
添加Web环境区分，development、production 和 追加常量的laravel的DB静态方法

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,25 @@
+ENV = 'development'
+
+[APP]
+DEBUG = true
+
+[SERVER]
+PROCESS_GROUP = ''
+PROCESS_USER = ''
+LISTEN = 'http://0.0.0.0:8787'
+NAME = 'webman'
+
+SESSION_DRIVER=file
+
+[DB]
+CONNECTION = mysql
+HOST = '127.0.0.1'
+PORT = 3306
+DATABASE = test
+USERNAME = root
+PASSWORD = 123456
+
+[REDIS]
+HOST = 127.0.0.1
+PASSWORD = ''
+PORT = 6379

--- a/.env
+++ b/.env
@@ -1,5 +1,7 @@
 ENV = 'development'
 
+SESSION_DRIVER=file
+
 [APP]
 DEBUG = true
 
@@ -8,8 +10,6 @@ PROCESS_GROUP = ''
 PROCESS_USER = ''
 LISTEN = 'http://0.0.0.0:8787'
 NAME = 'webman'
-
-SESSION_DRIVER=file
 
 [DB]
 CONNECTION = mysql

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,20 @@
+[DB]
+CONNECTION = mysql
+HOST = '127.0.0.1'
+PORT = 3306
+DATABASE = test
+USERNAME = root
+PASSWORD = 123456
+
+[REDIS]
+HOST = 127.0.0.1
+PASSWORD = ''
+PORT = 6379
+
+
+[SERVER]
+PROCESS_GROUP = ''
+PROCESS_USER = ''
+LISTEN = 'http://0.0.0.0:8787'
+NAME = 'webman'
+COUNT = 2

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,19 @@
+[DB]
+CONNECTION = mysql
+HOST = '127.0.0.1'
+PORT = 3306
+DATABASE = test
+USERNAME = root
+PASSWORD = 123456
+
+[REDIS]
+HOST = 127.0.0.1
+PASSWORD = ''
+PORT = 6379
+
+
+[SERVER]
+PROCESS_GROUP = ''
+PROCESS_USER = ''
+LISTEN = 'http://0.0.0.0:8787'
+NAME = 'webman'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .env
 /tests/tmp
 /tests/.phpunit.result.cache
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /.vscode
 /vendor
 *.log
-.env
 /tests/tmp
 /tests/.phpunit.result.cache
 composer.lock

--- a/app/controller/Index.php
+++ b/app/controller/Index.php
@@ -1,14 +1,12 @@
 <?php
 namespace app\controller;
 
-use support\Env;
 use support\Request;
 
 class Index
 {
     public function index(Request $request)
     {
-        var_dump(Env::get());
         return response('hello webman');
     }
 

--- a/app/controller/Index.php
+++ b/app/controller/Index.php
@@ -1,12 +1,14 @@
 <?php
 namespace app\controller;
 
+use support\Env;
 use support\Request;
 
 class Index
 {
     public function index(Request $request)
     {
+        var_dump(Env::get());
         return response('hello webman');
     }
 

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,7 @@
   },
   "require": {
     "php": ">=7.2",
-    "workerman/webman-framework": "^1.0",
-    "monolog/monolog": "^2.0",
-    "illuminate/database": "^8.0",
-    "illuminate/events": "^8.77"
+    "workerman/webman-framework": "^1.0"
   },
   "suggest": {
     "ext-event": "For better performance. "

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
   "require": {
     "php": ">=7.2",
     "workerman/webman-framework": "^1.0",
-    "monolog/monolog": "^2.0"
+    "monolog/monolog": "^2.0",
+    "illuminate/database": "^8.0",
+    "illuminate/events": "^8.77"
   },
   "suggest": {
     "ext-event": "For better performance. "

--- a/start.php
+++ b/start.php
@@ -16,6 +16,10 @@ use support\Container;
 ini_set('display_errors', 'on');
 error_reporting(E_ALL);
 
+if (file_exists(base_path().'/.env')) {
+    \support\Env::load(base_path().'/.env');
+}
+
 if (class_exists('Dotenv\Dotenv') && file_exists(base_path().'/.env')) {
     if (method_exists('Dotenv\Dotenv', 'createUnsafeImmutable')) {
         Dotenv::createUnsafeImmutable(base_path())->load();

--- a/support/Db.php
+++ b/support/Db.php
@@ -14,19 +14,25 @@
 namespace support;
 
 use Illuminate\Database\Capsule\Manager;
+use Illuminate\Database\Connection;
 
 /**
  * Class Db
  * @package support
  * @method static array select(string $query, $bindings = [], $useReadPdo = true)
- * @method static int insert(string $query, $bindings = [])
+ * @method static mixed selectOne(string $query, $bindings = [], $useReadPdo = true)
+ * @method static array selectFromWriteConnection(string $query, $bindings = [], $useReadPdo = true)
+ * @method static bool unprepared(string $query)
+ * @method static bool insert(string $query, $bindings = [])
+ * @method static bool statement(string $query, $bindings = [])
  * @method static int update(string $query, $bindings = [])
  * @method static int delete(string $query, $bindings = [])
- * @method static bool statement(string $query, $bindings = [])
+ * @method static int affectingStatement(string $query, $bindings = [])
  * @method static mixed transaction(\Closure $callback, $attempts = 1)
  * @method static void beginTransaction()
  * @method static void rollBack($toLevel = null)
  * @method static void commit()
+ * @method static Connection beforeExecuting(\Closure $callback)
  */
 class Db extends Manager
 {

--- a/support/Db.php
+++ b/support/Db.php
@@ -19,6 +19,8 @@ use Illuminate\Database\Connection;
 /**
  * Class Db
  * @package support
+ *
+ * @method static \Illuminate\Database\Query\Expression raw($value)
  * @method static array select(string $query, $bindings = [], $useReadPdo = true)
  * @method static mixed selectOne(string $query, $bindings = [], $useReadPdo = true)
  * @method static array selectFromWriteConnection(string $query, $bindings = [], $useReadPdo = true)

--- a/support/Env.php
+++ b/support/Env.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace support;
+
+class Env
+{
+    /**
+     * 环境变量数据
+     *
+     * @var array
+     */
+    protected static $data = [];
+
+    /**
+     * 读取环境变量定义文件
+     *
+     * @param string $file 环境变量定义文件
+     * @return void
+     */
+    public static function load(string $file): void {
+        if (!file_exists($file)) {
+            return;
+        }
+        $env = parse_ini_file($file, true);
+        if (isset($env['ENV']) && file_exists(base_path().'/.env.'.$env['ENV'])) {
+            $_env = parse_ini_file(base_path().'/.env.'.$env['ENV'], true);
+            $env = array_merge($env, $_env);
+        }
+        self::set($env);
+    }
+
+    /**
+     * 获取环境变量值
+     *
+     * @param string|null $name 环境变量名
+     * @param mixed $default 默认值
+     */
+    public static function get(string $name = null, $default = null) {
+        if ($name === null) {
+            return self::$data;
+        }
+        $name = strtoupper(str_replace('.', '_', $name));
+        return self::$data[$name] ?? $default;
+    }
+
+    /**
+     * 设置环境变量值
+     *
+     * @param string|array $env 环境变量
+     * @param mixed $value 值
+     * @return void
+     */
+    public static function set($env, $value = null): void {
+        if (is_array($env)) {
+            $env = array_change_key_case($env, CASE_UPPER);
+            foreach ($env as $key => $val) {
+                if (is_array($val)) {
+                    foreach ($val as $k => $v) {
+                        self::$data[$key . '_' . strtoupper($k)] = $v;
+                    }
+                } else {
+                    self::$data[$key] = $val;
+                }
+            }
+        } else {
+            $name = strtoupper(str_replace('.', '_', $env));
+            self::$data[$name] = $value;
+        }
+    }
+}


### PR DESCRIPTION
可以模仿VUE 的环境分 .env .env.development .env.proudction
根据 .env 中的 `ENV` 决定 是开发还是生产。
后面的环境变量如果和env的重复，则自动覆盖，已后面的为准。

实际中开发中，确实需要这个功能，虽然walkor大佬的意见[新版webman,取消env的原因是什么?](https://www.workerman.net/q/7534)。但是还是希望方便大家的使用。