### PR TITLE
windows下开发，每个进程统一workman 日志文件

### DIFF
--- a/windows.php
+++ b/windows.php
@@ -38,6 +38,11 @@ if (is_callable('opcache_reset')) {
 Config::load(config_path(), ['route', 'container']);
 
 worker_start('$process_name', config('process')['$process_name']);
+
+if (DIRECTORY_SEPARATOR != "/") {
+    Worker::\$logFile = config('server')['log_file'] ?? Worker::\$logFile;
+}
+
 Worker::runAll();
 
 EOF;
@@ -67,6 +72,11 @@ if (is_callable('opcache_reset')) {
 Config::load(config_path(), ['route', 'container']);
 
 worker_start("plugin.$firm.$name.$process_name", config("plugin.$firm.$name.process")['$process_name']);
+
+if (DIRECTORY_SEPARATOR != "/") {
+    Worker::\$logFile = config('server')['log_file'] ?? Worker::\$logFile;
+}
+
 Worker::runAll();
 
 EOF;


### PR DESCRIPTION
最近在研究webman的时候，发现在windows 下利用windows.php 启动时，如果除了业务进程，还有其它进程，例如监控，消费者等进程时。除了业务进程，其它进程在出现异常的时候，在日志文件找不到相应的信息，然后看源码，最终确认在vendor下的workman目录中的workerman.log。 所以在windows.php 中针对windows 加了一个兼容。避免写的异常日志到vendor目录下。