### PR TITLE
windows: load env before Config load

### DIFF
--- a/windows.php
+++ b/windows.php
@@ -4,12 +4,21 @@
  */
 require_once __DIR__ . '/vendor/autoload.php';
 
+use Dotenv\Dotenv;
 use process\Monitor;
 use Workerman\Worker;
 use Webman\Config;
 
 ini_set('display_errors', 'on');
 error_reporting(E_ALL);
+
+if (class_exists('Dotenv\Dotenv') && file_exists(base_path() . '/.env')) {
+    if (method_exists('Dotenv\Dotenv', 'createUnsafeImmutable')) {
+        Dotenv::createUnsafeImmutable(base_path())->load();
+    } else {
+        Dotenv::createMutable(base_path())->load();
+    }
+}
 
 Config::load(config_path(), ['route', 'container']);
 


### PR DESCRIPTION
windows 启动加载 Config 前配置 env，否则会导致 Config 里的数据有问题