### PR TITLE
fix:修复windows下 php 所在位置包含空格引发的文件检查失败

### DIFF
--- a/process/Monitor.php
+++ b/process/Monitor.php
@@ -93,7 +93,7 @@ class Monitor
             // check mtime
             if ($last_mtime < $file->getMTime() && in_array($file->getExtension(), $this->_extensions, true)) {
                 $var = 0;
-                exec(PHP_BINARY . " -l " . $file, $out, $var);
+                exec('"'.PHP_BINARY . '" -l ' . $file, $out, $var);
                 if ($var) {
                     $last_mtime = $file->getMTime();
                     continue;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28970107/174093698-7d565250-f8e2-4380-b3ee-ad516a8e2920.png)

![image](https://user-images.githubusercontent.com/28970107/174093758-328e0f0b-926a-4cc6-aade-923f1caef873.png)

对完整的php所在路径加入双引号包裹