### PR TITLE
进程名称添加应用名前缀

### DIFF
--- a/start.php
+++ b/start.php
@@ -103,12 +103,12 @@ if ($config['listen']) {
 // Windows does not support custom processes.
 if (\DIRECTORY_SEPARATOR === '/') {
     foreach (config('process', []) as $process_name => $config) {
-        worker_start($process_name, $config);
+        worker_start(config('server.name') . '.' . $process_name, $config);
     }
     foreach (config('plugin', []) as $firm => $projects) {
         foreach ($projects as $name => $project) {
             foreach ($project['process'] ?? [] as $process_name => $config) {
-                worker_start("plugin.$firm.$name.$process_name", $config);
+                worker_start(config('server.name') . ".plugin.$firm.$name.$process_name", $config);
             }
         }
     }


### PR DESCRIPTION
单机多应用部署进程名称容易混淆，进程名称添加应用名前缀