### PR TITLE
Using `PHP_BINARY` replaces `php`

### DIFF
--- a/windows.php
+++ b/windows.php
@@ -93,7 +93,7 @@ if ($monitor_config = config('process.monitor.constructor')) {
 
 function popen_processes($process_files)
 {
-    $cmd = "php " . implode(' ', $process_files);
+    $cmd = '"' . PHP_BINARY . '" ' . implode(' ', $process_files);
     $descriptorspec = [STDIN, STDOUT, STDOUT];
     $resource = proc_open($cmd, $descriptorspec, $pipes);
     if (!$resource) {


### PR DESCRIPTION
In Windows, user may specify different php version executables.
![demo](https://user-images.githubusercontent.com/4644588/199002776-d37d9e56-c789-478f-a245-bee8ff8dc328.png)
