### PR TITLE
Fix illuminate/container make

### DIFF
--- a/config/process.php
+++ b/config/process.php
@@ -21,7 +21,7 @@ return [
         'reloadable' => false,
         'constructor' => [
             // Monitor these directories
-            'monitor_dir' => array_merge([
+            'monitorDir' => array_merge([
                 app_path(),
                 config_path(),
                 base_path() . '/process',
@@ -30,7 +30,7 @@ return [
                 base_path() . '/.env',
             ], glob(base_path() . '/plugin/*/app'), glob(base_path() . '/plugin/*/config'), glob(base_path() . '/plugin/*/api')),
             // Files with these suffixes will be monitored
-            'monitor_extensions' => [
+            'monitorExtensions' => [
                 'php', 'html', 'htm', 'env'
             ],
             'options' => [


### PR DESCRIPTION
当使用 `illuminate/container` 时
`Container::make($config['handler'], $config['constructor'] ?? [])`  会需要用到 constructor 的参数名，1.5.0版本更改了 Monitor 的 __construct 的参数名
会报异常错误 `Illuminate\Contracts\Container\BindingResolutionException: Unresolvable dependency resolving [Parameter #0 [ <required> $monitorDir ]] in class process\Monitor`