### PR TITLE
Update helpers.php

### DIFF
--- a/support/helpers.php
+++ b/support/helpers.php
@@ -533,3 +533,14 @@ function cpu_count(): int
     }
     return $count > 0 ? $count : 4;
 }
+
+/**
+ * get GET or POST request parameters, if no parameter name is passed, an array of all values is returned, default values is supported
+ * @param string|null $param param's name
+ * @param string|null $default default value
+ * @return mixed|null
+ */
+function input(string $param = null, string $default = null)
+{
+    return is_null($param) ? request()->all() : request()->input($param, $default);
+}


### PR DESCRIPTION
添加input助手函数, 可以方便获取GET或POST中的数据,支持默认值. 如果不传入参数名称, 会返回所有参数键值对的数组.
使用方式完全复刻ThinkPHP的input()助手函数, 不仅为了方便ThinkPHP开发者, Copilot等的AI类代码提示助手, 也习惯使用input()函数获取参数. 