### PR TITLE
多应用模式的域名路由解决方案

### DIFF
--- a/config/domain.php
+++ b/config/domain.php
@@ -1,0 +1,11 @@
+<?php
+return [
+    //是否开启域名路由
+    'enable' => true,
+    // 多应用绑定关系
+    'bind' => [
+        // 'abc.com' => '', // 不属于任何应用
+        'abcd'  => 'touser', // 绑定到touser应用
+        'abce'  => 'toadmin', // 绑定到toadmin应用
+    ]
+];

--- a/support/Request.php
+++ b/support/Request.php
@@ -20,5 +20,21 @@ namespace support;
  */
 class Request extends \Webman\Http\Request
 {
-
+    //重写获取path用于多路由
+    public function path()
+    {
+        if (!isset($this->_data['path'])) {
+            if(config('domain.enable', false)){
+                //如果开启了域名路由
+                $uri = $this->uri();
+                $bind = config('domain.bind', []);
+                $domain = $this->host(true);
+                if(isset($bind[$domain])) {
+                    $uri = '/' . $bind[$domain] . $uri;
+                }
+            }
+            $this->_data['path'] = (string)\parse_url($uri, PHP_URL_PATH);
+        }
+        return $this->_data['path'];
+    }
 }


### PR DESCRIPTION
       之前一直在用tp的域名路由做一些应用绑定，在搭建站点的时候，考虑了webman，也在寻找域名路由的替代方式。后来找到了https://www.workerman.net/q/5908这个求助贴，也出来了https://www.workerman.net/plugin/11这个插件，但是总觉的哪里不对，然后发现路由上，我还是得加上应用的路由名称，比如toadmin应用，我还是得访问 /toadmin/config 才能访问，如果要省略掉/toadmin，那么还得在nginx上做代理。  嗯。。。 我好像就是想去掉nginx，结果还是不得用上？
      然后大概看了下原理，我觉的对这个需求来说，更多的是想让访问域名直接访问到自己想要的应用中，那么应该是在请求的路由中进行更改，而非直接限制寻找的应用 app。
       所以我重写了path方法，这个方法先进行了是否开启域名路由判断，然后再进行路由的寻找，如果有配置，那么自动更改请求的路由，比如 abcd.com 域名我指向了 toadmin，  那么前端访问abcd.com/config的时候，我自动在abcd.com后面加/toadmin，就变成了 abcd.com/toadmin/config，  这样其实就是实现了限制abcd.com访问toadmin应用。
       而对于开启路由配置模式的来说，每个不同应用路由需要用分组：Route::group('/toadmin', function () {}) 包起来而已。 当然如果有人，尝试把Route::group('/toadmin', function () {})  里面的子路由写向了 touser 应用的控制器，那么通过abcd.com 域名也是能访问到的，而我觉的这个是允许的，而且有必要的，因为的确会存在一些公共控制器的情况，比如toadmin、touser都有个路由 域名/config 读取 行政区域数据， 那么这个控制器是可以写在common应用中的，而通过 路由的形式进行指向，而不是需要必须在toadmin、touser上各写一个，当然如果开发人员乱用，我觉的是开发人员本身不规范导致的问题。
       这个迭代应该是替代[多应用域名绑定插件](https://www.workerman.net/plugin/11#%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E5%A4%9A%E5%BA%94%E7%94%A8%E5%9F%9F%E5%90%8D%E7%BB%91%E5%AE%9A%E6%8F%92%E4%BB%B6%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20)的方式，而且实现了不需要通过nginx代理即可实现短url
       
<img width="776" alt="image" src="https://github.com/walkor/webman/assets/13807765/7185bd22-35d2-4ce0-8551-1b3c76780b70">
<img width="589" alt="image" src="https://github.com/walkor/webman/assets/13807765/9af6ab03-1026-4d18-af0c-cdd43180ee1f">
<img width="592" alt="image" src="https://github.com/walkor/webman/assets/13807765/f6585b10-8011-4db9-a11f-9bb0e65251e3">

