### PR TITLE
允许json助手函数接收一个可选参数来设置HTTP状态码

### DIFF
--- a/support/helpers.php
+++ b/support/helpers.php
@@ -135,12 +135,13 @@ function response(string $body = '', int $status = 200, array $headers = []): Re
 /**
  * Json response
  * @param $data
+ * @param int $code
  * @param int $options
  * @return Response
  */
-function json($data, int $options = JSON_UNESCAPED_UNICODE): Response
+function json($data, int $code = 200, int $options = JSON_UNESCAPED_UNICODE): Response
 {
-    return new Response(200, ['Content-Type' => 'application/json'], \json_encode($data, $options));
+    return new Response($code, ['Content-Type' => 'application/json'], \json_encode($data, $options));
 }
 
 /**


### PR DESCRIPTION
webman的support/helpers.php自带一个json函数来生成一个返回json的响应，但这个响应默认为200而且无法通过参数设置。
在实际使用中，返回json的时候不仅仅会使用200状态码，还经常用到其他的状态码，例如400，404，403，401。
而如果修改helpers.php的话，在开发过程中，每次更新依赖的时候helpers.php都会被覆盖，每次都得手动回滚。
虽然可以开个新的助手函数（例如json_response），但这样的话又不够标准，而且以后合作的时候别人用了Webman自带的json会头疼的。
因此我做了个小改动。