### PR TITLE
Update log.php

### DIFF
--- a/config/log.php
+++ b/config/log.php
@@ -20,7 +20,7 @@ return [
                 'constructor' => [
                     runtime_path() . '/logs/webman.log',
                     7, //$maxFiles
-                    Monolog\Logger::DEBUG,
+                    Monolog\Level::Debug,
                 ],
                 'formatter' => [
                     'class' => Monolog\Formatter\LineFormatter::class,


### PR DESCRIPTION
原Monolog\Logger::DEBUG方法已被弃用，改用Monolog\Level::Debug