### PR TITLE
Add Docker support for webman deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM php:8.3.22-cli-alpine
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
+  && apk update --no-cache \
+  && docker-php-source extract
+
+# install extensions
+RUN docker-php-ext-install pdo pdo_mysql -j$(nproc) pcntl
+
+# enable opcache and pcntl
+RUN docker-php-ext-enable opcache pcntl
+RUN docker-php-source delete \
+    rm -rf /var/cache/apk/*
+
+RUN mkdir -p /app
+WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  webman:
+    build: .
+    container_name: docker-webman
+    restart: unless-stopped
+    volumes:
+      - "./:/app"
+    ports:
+      - "8787:8787"
+    command: ["php", "start.php", "start" ]


### PR DESCRIPTION
- Add Dockerfile with PHP 8.3.22 CLI Alpine image
- Configure PHP extensions: pdo, pdo_mysql, pcntl, opcache
- Add docker-compose.yml for container orchestration
- Enable hot-reload with volume mounting
- Expose port 8787 for webman service

🤖 Generated with [Claude Code](https://claude.ai/code)